### PR TITLE
Removed unneeded Zookeeper restart on every run

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Restart zookeeper
+  service: name=zookeeper state=restarted

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -33,15 +33,21 @@
 - name: Upstart script.
   template: src=zookeeper.conf.j2 dest=/etc/init/zookeeper.conf
   tags: deploy
+  notify:
+    - Restart zookeeper
 
 - name: Write myid file.
   template: src=myid.j2 dest={{data_dir}}/myid owner=zookeeper group=zookeeper
   tags: deploy
+  notify:
+    - Restart zookeeper
 
 - name: Configure zookeeper
   template: src=zoo.cfg.j2 dest={{ zookeeper_dir }}/conf/zoo.cfg owner=zookeeper group=zookeeper
   tags: deploy
+  notify:
+    - Restart zookeeper
 
 - name: Start zookeeper
-  service: name=zookeeper state=restarted 
+  service: name=zookeeper state=started
   tags: deploy


### PR DESCRIPTION
Zookeeper service had state=restarted which cause that every time
when playbook were run, Zookeeper restart.
Added restart handler added notifications to all config files and
changed state to "started".