### PR TITLE
Fix #12 error in zoo.cfg.j2 template

### DIFF
--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -5,11 +5,7 @@ clientPort={{ client_port }}
 initLimit={{ init_limit }}
 syncLimit={{ sync_limit }}
 
-{#
-Also consider:
-server.{{server.id}}={{server.host}}:2888:3888
-#}
 
 {% for server in zookeeper_hosts %}
-server.{{loop.index}}={{server.host}}:2888:3888
+server.{{loop.index}}={{ hostvars[server]['ansible_hostname'] }}:2888:3888
 {% endfor %}


### PR DESCRIPTION
This patch looks up the relevant host name
of the server. This requires your nodes
to be reachable by their respective ansible
host name.