### PR TITLE
support cluster/replicated mode

### DIFF
--- a/ci/playbook-cluster.yml
+++ b/ci/playbook-cluster.yml
@@ -1,0 +1,15 @@
+---
+#
+# Test Playbook
+#
+
+- hosts: cluster_hosts
+  vars:
+    install_mode: "cluster"
+  connection: local
+  sudo: yes
+
+  roles:
+    - {role: ../../}
+
+- include: tests.yml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,13 +9,13 @@ client_port: 2181
 init_limit: 5
 sync_limit: 2
 tick_time: 2000
-zoo_id: 1
 data_dir: /var/lib/zookeeper
 log_dir: /var/log/zookeeper
 zookeeper_dir: /opt/zookeeper-{{zookeeper_version}}
+install_modes_list: ["standalone","cluster"]
 
-# List of dict (i.e. {zookeeper_hosts:[{host:,id:},{host:,id:},...]})
-zookeeper_hosts:
-  - host: "{{inventory_hostname}}" # the machine running 
-    id: 1
-
+# installation mode: only two modes
+#   standalone (default value)
+#   cluster
+install_mode: standalone
+zoo_id: 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Check installation valid mode
+  shell: echo {{ install_mode in install_modes_list }}
+  register: command_result
+  failed_when: "'False' in command_result.stdout"
+
 - include: Debian.yml
   when: ansible_os_family == 'Debian'
 

--- a/templates/myid.j2
+++ b/templates/myid.j2
@@ -1,1 +1,9 @@
+{% if install_mode == "standalone" %}
 {{ zoo_id }}
+{% elif install_mode == "cluster" %}
+{% for server in play_hosts %}
+{% if server == inventory_hostname %}
+{{loop.index}}
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -5,11 +5,10 @@ clientPort={{ client_port }}
 initLimit={{ init_limit }}
 syncLimit={{ sync_limit }}
 
-{#
-Also consider:
-server.{{server.id}}={{server.host}}:2888:3888
-#}
-
-{% for server in zookeeper_hosts %}
-server.{{loop.index}}={{server.host}}:2888:3888
+{% if install_mode == "standalone" %}
+server.{{zoo_id}}={{inventory_hostname}}:2888:3888
+{% elif install_mode == "cluster" %}
+{% for server in play_hosts %}
+server.{{loop.index}}={{server}}:2888:3888
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
* support two modes: standalone (default mode) and replicated mode;
* update template configuration files and playbooks to enable cluster mode;
* fully test on Ubuntu and Redhat against these two modes;