### PR TITLE
allow a list or dict of zookeeper hosts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@ log_dir: /var/log/zookeeper
 zookeeper_dir: /opt/zookeeper-{{zookeeper_version}}
 
 # List of dict (i.e. {zookeeper_hosts:[{host:,id:},{host:,id:},...]})
+# No ... list of hostnames
 zookeeper_hosts:
-  - host: "{{inventory_hostname}}" # the machine running 
-    id: 1
+  - "{{inventory_hostname}}" # the machine running 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,3 +4,7 @@
 
 - include: RedHat.yml
   when: ansible_os_family == 'RedHat'
+
+- name: install cleanup cron
+  cron: name="Zookeeper Cleanup" hour=3 minute=0 state=present
+        job="ls -1drt {{ data_dir }}/version-2/* | head --lines=-6 | xargs sudo rm -f"

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -2,14 +2,20 @@ tickTime={{ tick_time }}
 dataDir={{ data_dir }}
 dataLogDir={{ log_dir }}
 clientPort={{ client_port }}
+
+{# More than 1 host ==> Quorum #}
+
+{% if zookeeper_hosts|length > 1 %}
 initLimit={{ init_limit }}
 syncLimit={{ sync_limit }}
+{% endif %}
 
-{#
-Also consider:
-server.{{server.id}}={{server.host}}:2888:3888
-#}
-
+{% if zookeeper_hosts is sequence %}
+{% for server in zookeeper_hosts %}
+server.{{loop.index}}={{server}}:2888:3888
+{% endfor %}
+{% else %} {# otherwise should be a dict / could be tested with the jinja mapping test #}
 {% for server in zookeeper_hosts %}
 server.{{loop.index}}={{server.host}}:2888:3888
 {% endfor %}
+{% endif %}


### PR DESCRIPTION

 Improvements:
* Only provide quorum parameters to Zookeeper if there is more than 1 host.
* Allow for both `list` and `dict` based `zookeeper_hosts`
    * this allows you to pass `{{ groups.group_name }}` to `zookeeper_hosts`