### PR TITLE
Change the zookeeper_hosts variable from dictionary to list

### DIFF
--- a/ci/inventory
+++ b/ci/inventory
@@ -1,2 +1,2 @@
 [local]
-localhost
+localhost zoo_id=1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,8 +14,6 @@ data_dir: /var/lib/zookeeper
 log_dir: /var/log/zookeeper
 zookeeper_dir: /opt/zookeeper-{{zookeeper_version}}
 
-# List of dict (i.e. {zookeeper_hosts:[{host:,id:},{host:,id:},...]})
-zookeeper_hosts:
-  - host: "{{inventory_hostname}}" # the machine running 
-    id: 1
+zookeeper_hosts: 
+  - localhost
 

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -5,11 +5,6 @@ clientPort={{ client_port }}
 initLimit={{ init_limit }}
 syncLimit={{ sync_limit }}
 
-{#
-Also consider:
-server.{{server.id}}={{server.host}}:2888:3888
-#}
-
-{% for server in zookeeper_hosts %}
-server.{{loop.index}}={{server.host}}:2888:3888
+{% for host in zookeeper_hosts %}
+server.{{ hostvars[host].zoo_id }}={{ host }}:2888:3888
 {% endfor %}


### PR DESCRIPTION
If the zookeeper and the mesos master are in the same server, It is able to use like below.
```
zookeeper_hosts: "{{ groups.masters }}"
```

And the zoo_id variable is able to use In the inventory file like below.
```
[masters]
192.168.100.3 zoo_id=1
192.168.100.4 zoo_id=2
192.168.100.5 zoo_id=3
```