### PR TITLE
Bump default zookeeper_version to 3.4.7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ansible_playbook_version: 0.1
 zookeeper_playbook_version: "0.9.0"
-zookeeper_version: 3.4.6
+zookeeper_version: 3.4.7
 zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz
 
 apt_cache_timeout: 3600


### PR DESCRIPTION
Builds will fail if using 3.4.6 for the version because Apache removes
old versions from their mirrors for some ungodly reason.