### PR TITLE
Back to version 3.4.6

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ansible_playbook_version: 0.1
 zookeeper_playbook_version: "0.9.1"
-zookeeper_version: 3.4.7
+zookeeper_version: 3.4.6
 zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz
 
 apt_cache_timeout: 3600


### PR DESCRIPTION
Apache has removed ZK 3.4.7 from their mirrors, causing builds to fail again.

I followed up in #zookeeper to see why these releases keep disappearing from the mirrors,
so hopefully we'll get some answers as to how to prevent this going forward.

### 3.4.7
```
$ curl http://www.us.apache.org/dist/zookeeper/zookeeper-3.4.7/zookeeper-3.4.7.tar.gz -I
HTTP/1.1 404 Not Found
Date: Wed, 13 Jan 2016 17:21:26 GMT
Server: Apache/2.4.7 (Ubuntu)
Content-Type: text/html; charset=iso-8859-1
```
## 3.4.6
```
$ curl http://www.us.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz -I
HTTP/1.1 200 OK
Date: Wed, 13 Jan 2016 17:21:31 GMT
Server: Apache/2.4.7 (Ubuntu)
Last-Modified: Sun, 10 Jan 2016 17:11:22 GMT
ETag: "10e11ea-528fde8dfe9ec"
Accept-Ranges: bytes
Content-Length: 17699306
Cache-Control: max-age=3600
Expires: Wed, 13 Jan 2016 18:21:31 GMT
Access-Control-Allow-Origin: *
Content-Type: application/x-gzip
```
