### PR TITLE
get zookeper hosts from ipv4 adress.

### DIFF
--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -10,6 +10,6 @@ Also consider:
 server.{{server.id}}={{server.host}}:2888:3888
 #}
 
-{% for server in zookeeper_hosts %}
-server.{{loop.index}}={{server.host}}:2888:3888
+{% for server in groups['zookeeper_hosts'] %}
+server.{{loop.index}}={{hostvars[server]['ansible_eth0']['ipv4']['address']}}:2888:3888
 {% endfor %}

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -10,6 +10,6 @@ Also consider:
 server.{{server.id}}={{server.host}}:2888:3888
 #}
 
-{% for server in groups['zookeeper_hosts'] %}
+{% for server in zookeeper_hosts %}
 server.{{loop.index}}={{hostvars[server]['ansible_eth0']['ipv4']['address']}}:2888:3888
 {% endfor %}


### PR DESCRIPTION
this line was failing with
````
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "AnsibleUndefinedVariable: ERROR! 'unicode object' has no attribute 'host'"}
````
i was able to get it to work with this change. i don't have much of a clue if this is the right way.

any comments?