### PR TITLE
Make zookeeper service enabled for RedHat

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -65,5 +65,5 @@
     - Restart zookeeper
 
 - name: Start zookeeper
-  service: name=zookeeper state=started
+  service: name=zookeeper state=started enabled=yes
   tags: deploy


### PR DESCRIPTION
@JasonGiedymin 

It's already enabled for Debian https://github.com/AnsibleShipyard/ansible-zookeeper/blob/master/tasks/Debian.yml#L26 but somehow missed on RedHat.