### PR TITLE
Allow zookeeper hosts to accept list and hash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@
 language: python
 python: "2.7"
 
-env:
-  - SITE=playbook.yml
-
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install curl -y
@@ -17,7 +14,13 @@ install:
 
 script:
   # Check the role/playbook's syntax.
-  - "ansible-playbook -i ci/inventory ci/$SITE --syntax-check"
+  - "ansible-playbook -i ci/inventory ci/playbook.yml --syntax-check"
 
   # Run the ansible ci playbook
   - "ansible-playbook -i ci/inventory ci/playbook.yml --connection=local --sudo -vvvv"
+
+  # Run the ansible hosts list
+  - "ansible-playbook -i ci/inventory ci/hosts_list.yml --connection=local --sudo -vvvv"
+
+  # Run the ansible hosts hash
+  - "ansible-playbook -i ci/inventory ci/hosts_hash.yml --connection=local --sudo -vvvv"

--- a/ci/hosts_hash.yml
+++ b/ci/hosts_hash.yml
@@ -1,0 +1,23 @@
+---
+#
+# Host hash playbook
+#
+
+- hosts: localhost
+  connection: local
+  sudo: yes
+  roles:
+    - role: ../../
+      zookeeper_hosts:
+        - host: "{{inventory_hostname}}" # the machine running
+          id: 2
+
+- hosts: localhost
+  connection: local
+  sudo: yes
+  gather_facts: false
+  tasks:
+      # Expecting myid to be 2 as defined in zookeeper_hosts variable
+    - shell: "grep 2 /var/lib/zookeeper/myid"
+      register: status
+      failed_when: status.rc != 0

--- a/ci/hosts_list.yml
+++ b/ci/hosts_list.yml
@@ -1,0 +1,22 @@
+---
+#
+# Host list playbook
+#
+
+- hosts: localhost
+  connection: local
+  sudo: yes
+  roles:
+    - role: ../../
+      zookeeper_hosts:
+        - "{{inventory_hostname}}"
+
+- hosts: localhost
+  connection: local
+  sudo: yes
+  gather_facts: false
+  tasks:
+      # Expecting myid to be 1 defined by loop.index
+    - shell: "grep 1 /var/lib/zookeeper/myid"
+      register: status
+      failed_when: status.rc != 0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ansible_playbook_version: 0.1
-zookeeper_playbook_version: "0.9.1.1"
+zookeeper_playbook_version: "0.9.2"
 zookeeper_version: 3.4.6
 zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz
 
@@ -9,13 +9,11 @@ client_port: 2181
 init_limit: 5
 sync_limit: 2
 tick_time: 2000
-zoo_id: 1
 data_dir: /var/lib/zookeeper
 log_dir: /var/log/zookeeper
 zookeeper_dir: /opt/zookeeper-{{zookeeper_version}}
 
 # List of dict (i.e. {zookeeper_hosts:[{host:,id:},{host:,id:},...]})
 zookeeper_hosts:
-  - host: "{{inventory_hostname}}" # the machine running 
+  - host: "{{inventory_hostname}}" # the machine running
     id: 1
-

--- a/templates/myid.j2
+++ b/templates/myid.j2
@@ -1,1 +1,11 @@
-{{ zoo_id }}
+{% for server in zookeeper_hosts %}
+{% if server.host is defined %}
+{% if server.host == inventory_hostname %}
+{{ server.id }}
+{% endif %}
+{% else %}
+{% if server == inventory_hostname %}
+{{ loop.index }}
+{% endif %}
+{% endif %}
+{% endfor %}

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -5,11 +5,11 @@ clientPort={{ client_port }}
 initLimit={{ init_limit }}
 syncLimit={{ sync_limit }}
 
-{#
-Also consider:
-server.{{server.id}}={{server.host}}:2888:3888
-#}
 
 {% for server in zookeeper_hosts %}
-server.{{loop.index}}={{server.host}}:2888:3888
+{% if server.host is defined %}
+server.{{server.id}}={{server.host}}:2888:3888
+{% else %}
+server.{{loop.index}}={{server}}:2888:3888
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
@AnsibleShipyard/developers 

cc @sumantmurke (since I had this as dirty master for few weeks, decided to step in) @stevelle

This originates to https://github.com/ernestas-poskus/ansible-zookeeper/pull/1

> All host had zoo_id as 1 by default as it used from default template hence all
the zookeeper nodes were not able to work with each other.
This fix will help operators to specify server id for host. This will help
them to configure the multinode zookeeper
Also cleaned up zoo.conf by replacing use of loop.index to use of server.id
for full consistency.

I went step further and made hosts to accept both list & hash for convenience 

This allows to manipulate hosts in a following manner:

```yaml
- name: Zookeeper
  hosts: zookeepers
  sudo: yes
  roles:
    - role: ansible-zookeeper
      zookeeper_hosts: "{{groups['zookeepers']}}"
```

or 

```yaml
- name: Zookeeper
  hosts: zookeepers
  sudo: yes
  roles:
    - role: ansible-zookeeper
      zookeeper_hosts:
        - id: 1
          host: "{{groups['zookeepers'][0]}}"
        - id: 2
          host: "{{groups['zookeepers'][1]}}"
        - id: 3
          host: "{{groups['zookeepers'][2]}}"
        - id: 4
          host: "{{groups['zookeepers'][3]}}"
```