### PR TITLE
Add Ansible Galaxy webhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,6 @@ script:
 
   # Run the ansible hosts hash
   - "ansible-playbook -i ci/inventory ci/hosts_hash.yml --connection=local --sudo -vvvv"
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/


### PR DESCRIPTION
On new release this hook will reimport role on Ansible Galaxy else it must be done manually.

https://galaxy.ansible.com/AnsibleShipyard/ansible-zookeeper/

Intentionally not bumping version since this change does not affect role 