### PR TITLE
Do not overwrite myid file unless explicitly stated

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ ansible_playbook_version: 0.1
 zookeeper_playbook_version: "0.9.2"
 zookeeper_version: 3.4.6
 zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz
+zookeeper_force_myid: yes
 
 apt_cache_timeout: 3600
 client_port: 2181
@@ -12,6 +13,7 @@ tick_time: 2000
 data_dir: /var/lib/zookeeper
 log_dir: /var/log/zookeeper
 zookeeper_dir: /opt/zookeeper-{{zookeeper_version}}
+
 
 # List of dict (i.e. {zookeeper_hosts:[{host:,id:},{host:,id:},...]})
 zookeeper_hosts:

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -11,7 +11,7 @@
     - zookeeperd
 
 - name: Overwrite myid file.
-  template: src=myid.j2 dest=/etc/zookeeper/conf/myid
+  template: src=myid.j2 dest=/etc/zookeeper/conf/myid force="{{ zookeeper_force_myid }}"
   tags: deploy
   notify:
     - Restart zookeeper

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -53,7 +53,7 @@
     - Restart zookeeper
 
 - name: Write myid file.
-  template: src=myid.j2 dest={{data_dir}}/myid owner=zookeeper group=zookeeper
+  template: src=myid.j2 dest={{data_dir}}/myid owner=zookeeper group=zookeeper force="{{ zookeeper_force_myid }}"
   tags: deploy
   notify:
     - Restart zookeeper


### PR DESCRIPTION
By default ansible sets force=yes in the template command. Maintain existing myid file when deploying by setting `force_myid=no`.

Using this as a role and referencing hosts by alias break myid generation. This allows me to keep the existing myid file.