### PR TITLE
Zookeeper setup using offical tarball (also) on debian/ubuntu

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,10 @@ zookeeper_playbook_version: "0.9.2"
 zookeeper_version: 3.4.6
 zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz
 
+zookeeper_debian_apt_install: false
+zookeeper_debian_apt_uninstall: false
 apt_cache_timeout: 3600
+
 client_port: 2181
 init_limit: 5
 sync_limit: 2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,9 @@ zookeeper_playbook_version: "0.9.2"
 zookeeper_version: 3.4.6
 zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz
 
+# Flag that selects if systemd or upstart will be used for the init service:
+# Note: by default Ubuntu 15.04 and later use systemd (but support switch to upstart)
+zookeeper_debian_systemd_enabled: "{{ ansible_distribution_version|version_compare(15.04, '>=') }}"
 zookeeper_debian_apt_install: false
 apt_cache_timeout: 3600
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,6 @@ zookeeper_version: 3.4.6
 zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz
 
 zookeeper_debian_apt_install: false
-zookeeper_debian_apt_uninstall: false
 apt_cache_timeout: 3600
 
 client_port: 2181

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible Zookeeper Role
   company: http://michaelhamrah.com
   license: Apache 2
-  min_ansible_version: 1.2
+  min_ansible_version: 1.6
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your 

--- a/tasks/Debian-tarball.yml
+++ b/tasks/Debian-tarball.yml
@@ -2,9 +2,11 @@
 - include: tarball.yml
 
 - include: upstart.yml
+  when: not zookeeper_debian_systemd_enabled
   tags: deploy
 
 - include: systemd.yml
+  when: zookeeper_debian_systemd_enabled
   tags: deploy
 
 - name: Start zookeeper

--- a/tasks/Debian-tarball.yml
+++ b/tasks/Debian-tarball.yml
@@ -1,0 +1,12 @@
+---
+- include: tarball.yml
+
+- include: upstart.yml
+  tags: deploy
+
+- include: systemd.yml
+  tags: deploy
+
+- name: Start zookeeper
+  service: name=zookeeper state=started enabled=yes
+  tags: deploy

--- a/tasks/deb-uninstall.yml
+++ b/tasks/deb-uninstall.yml
@@ -1,0 +1,9 @@
+---
+- name: Start zookeeper service
+  service: name=zookeeper state=stopped enabled=no
+
+- name: Apt install required system packages.
+  apt: pkg={{item}} state=absent
+  with_items:
+    - zookeeper
+    - zookeeperd

--- a/tasks/deb-uninstall.yml
+++ b/tasks/deb-uninstall.yml
@@ -1,9 +1,0 @@
----
-- name: Start zookeeper service
-  service: name=zookeeper state=stopped enabled=no
-
-- name: Apt install required system packages.
-  apt: pkg={{item}} state=absent
-  with_items:
-    - zookeeper
-    - zookeeperd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-- include: deb-uninstall.yml
-  when: ansible_os_family == 'Debian' and zookeeper_debian_apt_uninstall
 
 - include: Debian.yml
   when: ansible_os_family == 'Debian' and zookeeper_debian_apt_install

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,12 @@
 ---
+- include: deb-uninstall.yml
+  when: ansible_os_family == 'Debian' and zookeeper_debian_apt_uninstall
+
 - include: Debian.yml
-  when: ansible_os_family == 'Debian'
+  when: ansible_os_family == 'Debian' and zookeeper_debian_apt_install
+
+- include: Debian-tarball.yml
+  when: ansible_os_family == 'Debian' and not zookeeper_debian_apt_install
 
 - include: RedHat.yml
   when: ansible_os_family == 'RedHat'

--- a/templates/zookeeper.conf.j2
+++ b/templates/zookeeper.conf.j2
@@ -13,5 +13,5 @@ umask 007
 kill timeout 300
 
 script
-    su -c "{{zookeeper_dir}}/bin/zkServer.sh start-foreground > /var/log/zookeeper/init-zookeeper.log" zookeeper
+    exec sudo -u zookeeper -g zookeeper {{zookeeper_dir}}/bin/zkServer.sh start-foreground > /var/log/zookeeper/init-zookeeper.log 2>&1
 end script


### PR DESCRIPTION
final PR to fix: https://github.com/AnsibleShipyard/ansible-zookeeper/issues/26

thx for review @ernestas-poskus 

Update: We could also extract the 2 'configure' tasks from tarball.yml, and re-use the same include file also in the old Debian.yml installation, to further reduce code duplication. Should I do in this PR?