### PR TITLE
configurable zookeeper environment vars …

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,3 +25,6 @@ zookeeper_dir: /opt/zookeeper-{{zookeeper_version}}
 zookeeper_hosts:
   - host: "{{inventory_hostname}}" # the machine running
     id: 1
+
+# Dict of ENV settings to be written into the (optional) conf/zookeeper-env.sh
+zookeeper_env: {}

--- a/tasks/common-config.yml
+++ b/tasks/common-config.yml
@@ -1,0 +1,7 @@
+---
+- name: Configure zookeeper-env.sh
+  template: src=zookeeper-env.sh.j2 dest={{ zookeeper_dir }}/conf/zookeeper-env.sh owner=zookeeper group=zookeeper
+  tags: deploy
+  notify:
+    - Restart zookeeper
+  when: zookeeper_env is defined and zookeeper_env|length > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,3 +8,5 @@
 
 - include: RedHat.yml
   when: ansible_os_family == 'RedHat'
+
+- include: common-config.yml

--- a/tasks/tarball.yml
+++ b/tasks/tarball.yml
@@ -42,3 +42,4 @@
   tags: deploy
   notify:
     - Restart zookeeper
+  when: zookeeper_env is defined and zookeeper_env|length > 0

--- a/tasks/tarball.yml
+++ b/tasks/tarball.yml
@@ -36,10 +36,3 @@
   tags: deploy
   notify:
     - Restart zookeeper
-
-- name: Configure zookeeper-env.sh
-  template: src=zookeeper-env.sh.j2 dest={{ zookeeper_dir }}/conf/zookeeper-env.sh owner=zookeeper group=zookeeper
-  tags: deploy
-  notify:
-    - Restart zookeeper
-  when: zookeeper_env is defined and zookeeper_env|length > 0

--- a/tasks/tarball.yml
+++ b/tasks/tarball.yml
@@ -31,8 +31,14 @@
   notify:
     - Restart zookeeper
 
-- name: Configure zookeeper
+- name: Configure zookeeper zoo.cfg
   template: src=zoo.cfg.j2 dest={{ zookeeper_dir }}/conf/zoo.cfg owner=zookeeper group=zookeeper
+  tags: deploy
+  notify:
+    - Restart zookeeper
+
+- name: Configure zookeeper-env.sh
+  template: src=zookeeper-env.sh.j2 dest={{ zookeeper_dir }}/conf/zookeeper-env.sh owner=zookeeper group=zookeeper
   tags: deploy
   notify:
     - Restart zookeeper

--- a/templates/zookeeper-env.sh.j2
+++ b/templates/zookeeper-env.sh.j2
@@ -1,0 +1,5 @@
+{% if zookeeper_env is defined %}
+{% for key, value in zookeeper_env.items() | sort %}
+{{key}}={{value}}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
(useful p.eg to configure logging to file)

@ernestas-poskus  this is the new feature that helps to fix the logging (to file) (ref: https://github.com/AnsibleShipyard/ansible-zookeeper/pull/34#issuecomment-238792967 )

Finally I added no settings in the defaults (though this would be useful, also for the purpose of a working example )

To enable for ex. file based logging, you would define following var:
```
zookeeper_env:
  ZOO_LOG_DIR: "/var/log/zookeeper"
  ZOO_LOG4J_PROP: "INFO,ROLLINGFILE"
```