### PR TITLE
Refactor the service init task into the common include

### DIFF
--- a/tasks/Debian-tarball.yml
+++ b/tasks/Debian-tarball.yml
@@ -8,7 +8,3 @@
 - include: systemd.yml
   when: zookeeper_debian_systemd_enabled
   tags: deploy
-
-- name: Start zookeeper
-  service: name=zookeeper state=started enabled=yes
-  tags: deploy

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -21,7 +21,3 @@
   tags: deploy
   notify:
     - Restart zookeeper
-
-- name: Start zookeeper service
-  service: name=zookeeper state=started enabled=yes
-  tags: deploy

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -11,7 +11,3 @@
 
 - include: systemd.yml
   tags: deploy
-
-- name: Start zookeeper
-  service: name=zookeeper state=started enabled=yes
-  tags: deploy

--- a/tasks/common-config.yml
+++ b/tasks/common-config.yml
@@ -1,9 +1,10 @@
 ---
-- name: Write myid file.
-  template: src=myid.j2 dest={{data_dir}}/myid owner=zookeeper group=zookeeper
+- name: Configure zookeeper-env.sh
+  template: src=zookeeper-env.sh.j2 dest={{ zookeeper_dir }}/conf/zookeeper-env.sh owner=zookeeper group=zookeeper
   tags: deploy
   notify:
     - Restart zookeeper
+  when: zookeeper_env is defined and zookeeper_env|length > 0
 
 - name: Start zookeeper service
   service: name=zookeeper state=started enabled=yes

--- a/tasks/common-config.yml
+++ b/tasks/common-config.yml
@@ -1,7 +1,10 @@
 ---
-- name: Configure zookeeper-env.sh
-  template: src=zookeeper-env.sh.j2 dest={{ zookeeper_dir }}/conf/zookeeper-env.sh owner=zookeeper group=zookeeper
+- name: Write myid file.
+  template: src=myid.j2 dest={{data_dir}}/myid owner=zookeeper group=zookeeper
   tags: deploy
   notify:
     - Restart zookeeper
-  when: zookeeper_env is defined and zookeeper_env|length > 0
+
+- name: Start zookeeper service
+  service: name=zookeeper state=started enabled=yes
+  tags: deploy


### PR DESCRIPTION
removes duplication by re-using the same task(s) in the common include

Note: Initially I planned to do the same for the 2 other config tasks (that write the 'myid' and 'zoo.cfg' files).
Unfortunately in the Debian(using apt) case, those 2 files are written in the zookeeper conf folder where-as for the redhat/debian-tarball case the `myid` gets written into the `data_dir` ).
In order to achieve this, we would require to introduce extra variables, that define the deploy path for these 2 files, and overwrite their default value for ex. for the debian(apt) case (for ex. using an vars include). 
Not sure if it's worth the trouble? (IMO no, in case debian(apt) support would be removed at some point)

@ernestas-poskus ?