### PR TITLE
Register the zookeeper bin dir in the PATH env variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_ver
 zookeeper_debian_systemd_enabled: "{{ ansible_distribution_version|version_compare(15.04, '>=') }}"
 zookeeper_debian_apt_install: false
 apt_cache_timeout: 3600
+zookeeper_register_path_env: false
 
 client_port: 2181
 init_limit: 5

--- a/tasks/tarball.yml
+++ b/tasks/tarball.yml
@@ -39,3 +39,7 @@
   tags: deploy
   notify:
     - Restart zookeeper
+
+- name: Add zookeeper's bin dir to the PATH
+  copy: content="export PATH=$PATH:{{zookeeper_dir}}/bin" dest="/etc/profile.d/zookeeper_path.sh" mode=755
+  when: zookeeper_register_path_env


### PR DESCRIPTION
optional/configurable registration of the zkCli (and other zookeeper tools) to the system's PATH
disabled by default

Note: this feature isn't enabled for the (old)debian installation, because the default `zookeeper_dir`
setting is not applying here (it should be `/usr/share/zookeeper`).