### PR TITLE
Debian package support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ zookeeper_autopurge_snapRetainCount: 10
 data_dir: /var/lib/zookeeper
 log_dir: /var/log/zookeeper
 zookeeper_dir: /opt/zookeeper-{{zookeeper_version}}
+zookeeper_conf_dir: {{zookeeper_dir}} # or /etc/zookeeper when zookeeper_debian_apt_install is true
 zookeeper_tarball_dir: /opt/src
 
 # List of dict (i.e. {zookeeper_hosts:[{host:,id:},{host:,id:},...]})

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ zookeeper_autopurge_snapRetainCount: 10
 
 data_dir: /var/lib/zookeeper
 log_dir: /var/log/zookeeper
-zookeeper_dir: /opt/zookeeper-{{zookeeper_version}}
+zookeeper_dir: /opt/zookeeper-{{zookeeper_version}} # or /usr/share/zookeeper when zookeeper_debian_apt_install is true
 zookeeper_conf_dir: {{zookeeper_dir}} # or /etc/zookeeper when zookeeper_debian_apt_install is true
 zookeeper_tarball_dir: /opt/src
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,7 @@ zookeeper_autopurge_snapRetainCount: 10
 
 data_dir: /var/lib/zookeeper
 log_dir: /var/log/zookeeper
-zookeeper_dir: /opt/zookeeper-{{zookeeper_version}}
+zookeeper_dir: "{{ zookeeper_debian_apt_install | ternary('/usr/share/zookeeper', '/opt/zookeeper-' + zookeeper_version) }}"
 zookeeper_conf_dir: "{{ zookeeper_debian_apt_install | ternary('/etc/zookeeper', zookeeper_dir) }}"
 zookeeper_tarball_dir: /opt/src
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ zookeeper_autopurge_snapRetainCount: 10
 data_dir: /var/lib/zookeeper
 log_dir: /var/log/zookeeper
 zookeeper_dir: /opt/zookeeper-{{zookeeper_version}}
+zookeeper_conf_dir: "{{ zookeeper_debian_apt_install | ternary('/etc/zookeeper', zookeeper_dir) }}"
 zookeeper_tarball_dir: /opt/src
 
 # Rolling file appender setttings

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -11,13 +11,13 @@
     - zookeeperd
 
 - name: Overwrite myid file.
-  template: src=myid.j2 dest=/etc/zookeeper/conf/myid force="{{ zookeeper_force_myid }}"
+  template: src=myid.j2 dest={{zookeeper_conf_dir}}/conf/myid force="{{ zookeeper_force_myid }}"
   tags: deploy
   notify:
     - Restart zookeeper
 
 - name: Overwrite default config file
-  template: src=zoo.cfg.j2 dest=/etc/zookeeper/conf/zoo.cfg
+  template: src=zoo.cfg.j2 dest={{zookeeper_conf_dir}}/conf/zoo.cfg
   tags: deploy
   notify:
     - Restart zookeeper

--- a/tasks/common-config.yml
+++ b/tasks/common-config.yml
@@ -1,13 +1,13 @@
 ---
 - name: Configure zookeeper-env.sh
-  template: src=zookeeper-env.sh.j2 dest={{ zookeeper_dir }}/conf/zookeeper-env.sh owner=zookeeper group=zookeeper
+  template: src=zookeeper-env.sh.j2 dest={{ zookeeper_conf_dir }}/conf/zookeeper-env.sh owner=zookeeper group=zookeeper
   tags: deploy
   notify:
     - Restart zookeeper
   when: zookeeper_env is defined and zookeeper_env|length > 0
 
 - name: Update the log4j config with saner production values
-  template: src=log4j.properties.j2 dest={{ zookeeper_dir }}/conf/log4j.properties
+  template: src=log4j.properties.j2 dest={{ zookeeper_conf_dir }}/conf/log4j.properties
   tags: deploy
   notify:
     - Restart zookeeper


### PR DESCRIPTION
Debian package uses different locations than assumed by the role.
This PR fixes this issue, without breaking the tarbal and RedHat locations/support.

A `zookeeper_conf_dir` variable is added to make the configuration location configurable, the default is set to `zookeeper_dir` (which was the hardcoded configuration location)

When `zookeeper_debian_apt_install` is true, the defaults are changed according to the Debian package locations.

If a users has other needs the default can be overridden by the user.
