### PR TITLE
Let handler (re)start zookeeper

### DIFF
--- a/tasks/common-config.yml
+++ b/tasks/common-config.yml
@@ -12,6 +12,6 @@
   notify:
     - Restart zookeeper
 
-- name: Start zookeeper service
-  service: name=zookeeper state=started enabled=yes
+- name: Enable zookeeper service
+  service: name=zookeeper enabled=yes
   tags: deploy


### PR DESCRIPTION
When installing zookeeper it gets (re)started twice, as enabling the service also starts it.
After the role finished the handler also (re)starts the service again.

By removing the optional (when `enabled` is used) `state` parameter it does not start at this at this task (but when the role finished), preventing (re)starting twice.