### PR TITLE
Make sure daemon-reload is executed first

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
-- name: Restart zookeeper
-  service: name=zookeeper state=restarted enabled=yes
-
 - name: Reload systemctl daemon
   command: systemctl daemon-reload
   when: ansible_service_mgr == 'systemd'
+
+- name: Restart zookeeper
+  service: name=zookeeper state=restarted


### PR DESCRIPTION
Reloading the service configuration(s) must be done before (re)starting the services in order for the configuration changes to be picked up.

Additionally, the `enabled=yes` parameter is already set in tasks/common-config.yml so it is removed