### PR TITLE
Support custom zookeeper debian apt repository (to use v3.4.8 on Ubuntu 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_ver
 # Note: by default Ubuntu 15.04 and later use systemd (but support switch to upstart)
 zookeeper_debian_systemd_enabled: "{{ ansible_distribution_version|version_compare(15.04, '>=') }}"
 zookeeper_debian_apt_install: false
+# (Optional:) add custom 'ppa' repositories depending on the distro version (only with debian_apt_install=true)
+# Example: to use a community zookeeper v3.4.8 deb pkg for Ubuntu 14.04 (where latest official is v3.4.5)
+zookeeper_debian_apt_repositories:
+  - repository_url: "ppa:ufscar/zookeeper"
+    distro_version: "14.04"
+
 apt_cache_timeout: 3600
 zookeeper_register_path_env: false
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Role Variables
 ```yaml
 ---
 ansible_playbook_version: 0.1
-zookeeper_playbook_version: "0.9.2"
+zookeeper_playbook_version: "0.17.0"
 zookeeper_version: 3.4.6
 zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_ver
 # Note: by default Ubuntu 15.04 and later use systemd (but support switch to upstart)
 zookeeper_debian_systemd_enabled: "{{ ansible_distribution_version|version_compare(15.04, '>=') }}"
 zookeeper_debian_apt_install: false
+zookeeper_debian_apt_repository: ""
 apt_cache_timeout: 3600
 zookeeper_register_path_env: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ansible_playbook_version: 0.1
-zookeeper_playbook_version: "0.9.2"
+zookeeper_playbook_version: "0.17.0"
 zookeeper_version: 3.4.6
 zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_ver
 # Note: by default Ubuntu 15.04 and later use systemd (but support switch to upstart)
 zookeeper_debian_systemd_enabled: "{{ ansible_distribution_version|version_compare(15.04, '>=') }}"
 zookeeper_debian_apt_install: false
-zookeeper_debian_apt_repository: ""
+zookeeper_debian_apt_repositories: []
 apt_cache_timeout: 3600
 zookeeper_register_path_env: false
 

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,4 +1,8 @@
 ---
+- name: Add custom apt repo (for additional zookeeper versions)
+  apt_repository: repo={{zookeeper_debian_apt_repository}} state=present
+  when: zookeeper_debian_apt_repository
+
 - name: Update apt cache
   apt: update_cache=yes cache_valid_time={{apt_cache_timeout}}
   tags: bootstrap

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,7 +1,9 @@
 ---
-- name: Add custom apt repo (for additional zookeeper versions)
-  apt_repository: repo={{zookeeper_debian_apt_repository}} state=present
-  when: zookeeper_debian_apt_repository
+- name: Add optional custom apt repositories (for additional zookeeper versions)
+  apt_repository: repo={{item.repository_url}} state=present
+  when: "{{ ansible_distribution_version|version_compare(item.distro_version, item.version_comparator|default('=')) }}"
+  with_items:
+    - "{{ zookeeper_debian_apt_repositories }}"
 
 - name: Update apt cache
   apt: update_cache=yes cache_valid_time={{apt_cache_timeout}}


### PR DESCRIPTION
by allowing to configure a custom (ppa) apt repos, we can use a community provided v3.4.8 deb-pkg based deployment  (which is more secure than using 'tarball' , when later installing `mesos`  which by default has 'zookeeper' in its dependencies).

Example config to make this work:
```
      zookeeper_debian_apt_repository: "ppa:ufscar/zookeeper"
      zookeeper_debian_apt_install: true
      zookeeper_version: 3.4.8
```