### PR TITLE
Remove 'z' from untar command

### DIFF
--- a/tasks/tarball.yml
+++ b/tasks/tarball.yml
@@ -32,7 +32,7 @@
     zookeeper_archive_s3_object is not defined
 
 - name: Unpack tarball.
-  command: tar zxf {{zookeeper_tarball_dir}}/zookeeper-{{zookeeper_version}}.tar.gz --strip-components=1 chdir={{zookeeper_dir}} creates={{zookeeper_dir}}/bin
+  command: tar xf {{zookeeper_tarball_dir}}/zookeeper-{{zookeeper_version}}.tar.gz --strip-components=1 chdir={{zookeeper_dir}} creates={{zookeeper_dir}}/bin
   tags: bootstrap
 
 - group: name=zookeeper system=yes


### PR DESCRIPTION
The latest Zookeeper version 3.5.3-beta is distributed as plain tar
archive, so `tar zxf` fails with `gzip: stdin: not in gzip format`.

Also, recent versions of tar recognize format by itself, so there is no
need in 'z' option.