### PR TITLE
Enable systemd service for Debian 8

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,10 @@ zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_ver
 
 # Flag that selects if systemd or upstart will be used for the init service:
 # Note: by default Ubuntu 15.04 and later use systemd (but support switch to upstart)
-zookeeper_debian_systemd_enabled: "{{ ansible_distribution_version|version_compare(15.04, '>=') }}"
+_ubuntu_1504: "{{ ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare(15.04, '>=') }}"
+_debian_8: "{{ ansible_distribution == 'Debian' and ansible_distribution_version|version_compare(8.0, '>=') }}"
+zookeeper_debian_systemd_enabled: "{{ _ubuntu_1504 or _debian_8 }}"
+
 zookeeper_debian_apt_install: false
 zookeeper_debian_apt_repositories: []
 apt_cache_timeout: 3600


### PR DESCRIPTION
Currently, when running ansible-zookeeper role on Debian 8 host, it
fails:

    TASK [AnsibleShipyard.ansible-zookeeper : Enable zookeeper service] 
    ***************************************************
    fatal: [debian8-host]: FAILED! => {"changed": false, "failed": true, "msg": "Could not find the requested service zookeeper: host"}

This happens because `zookeeper_debian_systemd_enabled` variable is
enabled only for Ubuntu >= 15.04 hosts.

This PR adds check for Debian >= 8.0, so Zookeeper successfully installs
on Debian 8.0