### PR TITLE
Make ZK startup only after network is up

### DIFF
--- a/templates/zookeeper.service.j2
+++ b/templates/zookeeper.service.j2
@@ -2,6 +2,8 @@
 
 [Unit]
 Description=ZooKeeper
+After=network.target
+Wants=network.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
In order to avoid name-resolution and connectivity issues to other cluster nodes, especially when a server reboot occurs, make sure ZK only starts up after the network has started up properly.