### PR TITLE
 3.4.9 unavailable - updated to 3.4.11

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-zookeeper_version: 3.4.9
+zookeeper_version: 3.4.11
 zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz
 
 # Flag that selects if systemd or upstart will be used for the init service:


### PR DESCRIPTION
This is failing because 3.4.9 is unavailable. Updated to 3.4.11

URL: http://www.us.apache.org/dist/zookeeper/
