### PR TITLE
Extracted hardcoded zookeeper ports into vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ sync_limit: 2
 tick_time: 2000
 zookeeper_autopurge_purgeInterval: 0
 zookeeper_autopurge_snapRetainCount: 10
+zookeeper_cluster_ports: "2888:3888"
 
 data_dir: /var/lib/zookeeper
 log_dir: /var/log/zookeeper

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,7 @@ sync_limit: 2
 tick_time: 2000
 zookeeper_autopurge_purgeInterval: 0
 zookeeper_autopurge_snapRetainCount: 10
+zookeeper_cluster_ports: "2888:3888"
 
 data_dir: /var/lib/zookeeper
 log_dir: /var/log/zookeeper

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -13,11 +13,11 @@ autopurge.snapRetainCount={{ zookeeper_autopurge_snapRetainCount }}
 {% for server in zookeeper_hosts %}
 {% if server.host is defined %}
 {% if server.ip is defined %}
-server.{{server.id}}={{server.ip}}:2888:3888
+server.{{server.id}}={{server.ip}}:{{zookeeper_cluster_ports}}
 {% else %}
-server.{{server.id}}={{server.host}}:2888:3888
+server.{{server.id}}={{server.host}}:{{zookeeper_cluster_ports}}
 {% endif %}
 {% else %}
-server.{{loop.index}}={{server}}:2888:3888
+server.{{loop.index}}={{server}}:{{zookeeper_cluster_ports}}
 {% endif %}
 {% endfor %}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -78,6 +78,7 @@
   vars:
     zookeeper_version: 3.4.11
     zookeeper_dir: /opt/zookeeper-{{zookeeper_version}}
+    zookeeper_cluster_ports: "2888:3888"
   tasks:
     # Expecting myid to be 2 as defined in zookeeper_hosts variable
     - shell: "grep 2 /var/lib/zookeeper/myid"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -85,7 +85,7 @@
       failed_when: status.rc != 0
 
     # Expecting zoo.cfg to include serve definition with custom IP
-    - shell: "grep 'server.2=192.168.0.1:2888:3888' {{ zookeeper_dir }}/conf/zoo.cfg"
+    - shell: "grep 'server.2=192.168.0.1:{{ zookeeper_cluster_ports }}' {{ zookeeper_dir }}/conf/zoo.cfg"
       register: status
       failed_when: status.rc != 0
 


### PR DESCRIPTION
Hi,

This playbook helped me a lot. That was just a little issue, that I could not setup custom ports for peer to peer node communication.

It was hardcoded to `2888:3888`. On my servers setup these ports are not accessible, so I needed to use another. I think that option to override those ports may be usefull.

Thanks!