### PR TITLE
Customize own hostname with a new variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ zookeeper_dir: /opt/zookeeper-{{zookeeper_version}} # or /usr/share/zookeeper wh
 zookeeper_conf_dir: {{zookeeper_dir}} # or /etc/zookeeper when zookeeper_debian_apt_install is true
 zookeeper_tarball_dir: /opt/src
 
+zookeeper_hosts_hostname: "{{inventory_hostname}}"
 # List of dict (i.e. {zookeeper_hosts:[{host:,id:},{host:,id:},...]})
 zookeeper_hosts:
-  - host: "{{inventory_hostname}}" # the machine running
+  - host: "{{zookeeper_hosts_hostname}}" # the machine running
     id: 1
 
 # Dict of ENV settings to be written into the (optional) conf/zookeeper-env.sh

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,9 +31,10 @@ zookeeper_tarball_dir: /opt/src
 zookeeper_rolling_log_file_max_size: 10MB
 zookeeper_max_rolling_log_file_count: 10
 
+zookeeper_hosts_hostname: "{{inventory_hostname}}"
 # List of dict (i.e. {zookeeper_hosts:[{host:,id:},{host:,id:},...]})
 zookeeper_hosts:
-  - host: "{{inventory_hostname}}" # the machine running
+  - host: "{{zookeeper_hosts_hostname}}" # the machine running
     id: 1
 
 # Dict of ENV settings to be written into the (optional) conf/zookeeper-env.sh

--- a/templates/myid.j2
+++ b/templates/myid.j2
@@ -1,10 +1,10 @@
 {% for server in zookeeper_hosts %}
 {% if server.host is defined %}
-{% if server.host == inventory_hostname %}
+{% if server.host == zookeeper_hosts_hostname %}
 {{ server.id }}
 {% endif %}
 {% else %}
-{% if server == inventory_hostname %}
+{% if server == zookeeper_hosts_hostname %}
 {{ loop.index }}
 {% endif %}
 {% endif %}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -23,7 +23,7 @@
   roles:
     - role: role_under_test
       zookeeper_hosts:
-        - host: "{{inventory_hostname}}" # the machine running
+        - host: "{{zookeeper_hosts_hostname}}" # the machine running
           id: 2
 
 - hosts: localhost
@@ -45,7 +45,7 @@
   roles:
     - role: role_under_test
       zookeeper_hosts:
-        - "{{inventory_hostname}}"
+        - "{{zookeeper_hosts_hostname}}"
 
 - hosts: localhost
   connection: local
@@ -68,7 +68,7 @@
       zookeeper_version: 3.4.11
       zookeeper_dir: /opt/zookeeper-{{zookeeper_version}}
       zookeeper_hosts:
-        - host: "{{inventory_hostname}}" # the machine running
+        - host: "{{zookeeper_hosts_hostname}}" # the machine running
           ip: '192.168.0.1'
           id: 2
 


### PR DESCRIPTION
There are sometimes when `inventory_hostname` is not the real hostname of your machine, and you want to specify which fact from ansible represents better your hostname.

For this I added `zookeeper_own_hostname` which by default equals to `inventory_hostname` but let you for instance overwrite it by `ansible_nodename` or whatever other variable or value you need.

This change is backwards compatible.