### PR TITLE
Remove filter as test which is going to be deprecated

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add optional custom apt repositories (for additional zookeeper versions)
   apt_repository: repo={{item.repository_url}} state=present
-  when: "{{ ansible_distribution_version|version_compare(item.distro_version, item.version_comparator|default('=')) }}"
+  when: "{{ ansible_distribution_version is version_compare(item.distro_version, item.version_comparator|default('=')) }}"
   with_items:
     - "{{ zookeeper_debian_apt_repositories }}"
 


### PR DESCRIPTION
With Ansible 2.6 this warning is shown:

```
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|version_compare` use `result 
is version_compare`. This feature will be removed in version 2.9. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```

This PR fixes this.