### PR TITLE
expose `clientPortAddress` zookeeper config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ apt_cache_timeout: 3600
 zookeeper_register_path_env: false
 
 client_port: 2181
+client_port_address: ~
 init_limit: 5
 sync_limit: 2
 tick_time: 2000

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -2,6 +2,9 @@ tickTime={{ tick_time }}
 dataDir={{ data_dir }}
 dataLogDir={{ log_dir }}
 clientPort={{ client_port }}
+{% if client_port_address is defined %}
+clientPortAddress={{ client_port_address }}
+{% endif %}
 initLimit={{ init_limit }}
 syncLimit={{ sync_limit }}
 maxClientCnxns={{ zookeeper_max_client_connections }}


### PR DESCRIPTION
Binding to all interfaces is less than ideal, and I didn't see the `clientPortAddress` option anywhere