### PR TITLE
replaced keyword 'installed' by 'present' as the former is deprecated.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,8 +4,8 @@ zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_ver
 
 # Flag that selects if systemd or upstart will be used for the init service:
 # Note: by default Ubuntu 15.04 and later use systemd (but support switch to upstart)
-_ubuntu_1504: "{{ ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare(15.04, '>=') }}"
-_debian_8: "{{ ansible_distribution == 'Debian' and ansible_distribution_version|version_compare(8.0, '>=') }}"
+_ubuntu_1504: "{{ ansible_distribution == 'Ubuntu' and ansible_distribution_version is version(15.04, '>=') }}"
+_debian_8: "{{ ansible_distribution == 'Debian' and ansible_distribution_version is version(8.0, '>=') }}"
 zookeeper_debian_systemd_enabled: "{{ _ubuntu_1504 or _debian_8 }}"
 
 zookeeper_debian_apt_install: false

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -10,7 +10,7 @@
   tags: bootstrap
 
 - name: Apt install required system packages.
-  apt: pkg={{item}} state=installed
+  apt: pkg={{item}} state=present
   tags: bootstrap
   with_items:
     - zookeeper


### PR DESCRIPTION
replaced keyword 'installed' by 'present' as the former is deprecated in ansible latest versions